### PR TITLE
fix: mark password and token as isSecret in config_schema

### DIFF
--- a/cmd/baton-jenkins/config.go
+++ b/cmd/baton-jenkins/config.go
@@ -6,9 +6,9 @@ import (
 
 var (
 	username = field.StringField("username", field.WithDescription("Username of administrator used to connect to the Jenkins API"), field.WithRequired(true))
-	password = field.StringField("password", field.WithDescription("Application password used to connect to the Jenkins API"))
+	password = field.StringField("password", field.WithDescription("Application password used to connect to the Jenkins API"), field.WithIsSecret(true))
 	baseUrl  = field.StringField("base-url", field.WithDescription("Jenkins"), field.WithDefaultValue("http://localhost:8080"), field.WithRequired(true))
-	token    = field.StringField("token", field.WithDescription("HTTP access tokens in Jenkins"))
+	token    = field.StringField("token", field.WithDescription("HTTP access tokens in Jenkins"), field.WithIsSecret(true))
 )
 
 var relationships = []field.SchemaFieldRelationship{


### PR DESCRIPTION
BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

The credential field(s) are defined in Go via the baton `field` package, which is the source the config schema is derived from (no separate generated config_schema.json is committed in this repo), so adding `field.WithIsSecret(true)` to the field definition is the complete fix.

<!-- stargate: connector-secret-audit-phase11 -->