### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -34,15 +34,14 @@ func groupResource(ctx context.Context, group client.Group, parentResourceID *v2
 		"group_name": group.ID,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		group.ID,
 		resourceTypeGroup,
 		group.ID,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/job.go
+++ b/pkg/connector/job.go
@@ -22,15 +22,14 @@ func jobResource(ctx context.Context, job client.Job, parentResourceID *v2.Resou
 		"node_name": job.Name,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		job.Name,
 		resourceTypeJob,
 		job.Name,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/node.go
+++ b/pkg/connector/node.go
@@ -22,15 +22,14 @@ func nodeResource(ctx context.Context, role client.Computer, parentResourceID *v
 		"node_name": role.AssignedLabels[0].Name,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		role.AssignedLabels[0].Name,
 		resourceTypeNode,
 		role.AssignedLabels[0].Name,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -31,15 +31,14 @@ func roleResource(ctx context.Context, role string, parentResourceID *v2.Resourc
 		"node_name": role,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		role,
 		resourceTypeRole,
 		role,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -36,8 +36,6 @@ func userResource(ctx context.Context, user client.Users, parentResourceID *v2.R
 
 	userStatus := v2.UserTrait_Status_STATUS_ENABLED
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
 		rs.WithEmail("", true),
 	}
 
@@ -46,6 +44,8 @@ func userResource(ctx context.Context, user client.Users, parentResourceID *v2.R
 		resourceTypeUser,
 		user.User.ID,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/view.go
+++ b/pkg/connector/view.go
@@ -22,15 +22,14 @@ func viewResource(ctx context.Context, view client.View, parentResourceID *v2.Re
 		"node_name": view.Name,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		view.Name,
 		resourceTypeView,
 		view.Name,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
